### PR TITLE
Issue#23: include relevant XML service specification in generated API…

### DIFF
--- a/CCSDS_COMMON_API/pom.xml
+++ b/CCSDS_COMMON_API/pom.xml
@@ -91,6 +91,10 @@
           <include>LICENCE.md</include>
         </includes>
       </resource>
+      <resource>
+        <directory>${esa.stubgen.xmlDirectory}</directory>
+        <targetPath>xml</targetPath>
+      </resource>
     </resources>
     
     <plugins>

--- a/CCSDS_COM_API/pom.xml
+++ b/CCSDS_COM_API/pom.xml
@@ -86,6 +86,10 @@
           <include>LICENCE.md</include>
         </includes>
       </resource>
+      <resource>
+        <directory>${esa.stubgen.xmlDirectory}</directory>
+        <targetPath>xml</targetPath>
+      </resource>
     </resources>
     
     <plugins>

--- a/CCSDS_MAL_API/pom.xml
+++ b/CCSDS_MAL_API/pom.xml
@@ -78,6 +78,10 @@
           <include>LICENCE.md</include>
         </includes>
       </resource>
+      <resource>
+        <directory>${esa.stubgen.xmlDirectory}</directory>
+        <targetPath>xml</targetPath>
+      </resource>
     </resources>
     
     <plugins>

--- a/CCSDS_MC_API/pom.xml
+++ b/CCSDS_MC_API/pom.xml
@@ -92,6 +92,10 @@
           <include>LICENCE.md</include>
         </includes>
       </resource>
+      <resource>
+        <directory>${esa.stubgen.xmlDirectory}</directory>
+        <targetPath>xml</targetPath>
+      </resource>
     </resources>
     
     <plugins>


### PR DESCRIPTION
… JARs

Including the relevant XML service specification file in a generated API
JAR provides a simple, definitive way to see the exact XML service
specification the generated stubs correspond to.

The XML service specification files are added in the directory 'xml', e.g.

    xml/ServiceDefMAL.xml

These files are not very big, and XML compresses very well, so the
increase in size is minimal.