### PR TITLE
Fix string based structures

### DIFF
--- a/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/Identifier.java
+++ b/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/Identifier.java
@@ -31,7 +31,6 @@ import org.ccsds.moims.mo.mal.MALException;
  */
 public class Identifier implements Attribute
 {
-
   private String value;
 
   /**
@@ -49,12 +48,15 @@ public class Identifier implements Attribute
    */
   public Identifier(final String value)
   {
-    if (null == value) {
+    if (null == value)
+    {
       Logger.getLogger(Identifier.class.getName()).log(Level.WARNING,
           "The Identifier has been initialized with an invalid null value. Problems might occur while encoding the element.",
           new MALException());
       this.value = "";
-    } else {
+    }
+    else
+    {
       this.value = value;
     }
   }
@@ -125,13 +127,16 @@ public class Identifier implements Attribute
   @Override
   public boolean equals(final Object obj)
   {
-    if (null == obj) {
+    if (null == obj)
+    {
       return false;
     }
-    if (this == obj) {
+    if (this == obj)
+    {
       return true;
     }
-    if (!(obj instanceof Identifier)) {
+    if (!(obj instanceof Identifier))
+    {
       return false;
     }
     return this.value.equals(((Identifier) obj).value);

--- a/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/Identifier.java
+++ b/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/Identifier.java
@@ -31,6 +31,7 @@ import org.ccsds.moims.mo.mal.MALException;
  */
 public class Identifier implements Attribute
 {
+
   private String value;
 
   /**
@@ -38,6 +39,7 @@ public class Identifier implements Attribute
    */
   public Identifier()
   {
+    this.value = "";
   }
 
   /**
@@ -47,14 +49,14 @@ public class Identifier implements Attribute
    */
   public Identifier(final String value)
   {
-    if(null == value)
-    {
-      Logger.getLogger(Identifier.class.getName()).log(Level.WARNING, 
+    if (null == value) {
+      Logger.getLogger(Identifier.class.getName()).log(Level.WARNING,
           "The Identifier has been initialized with an invalid null value. Problems might occur while encoding the element.",
           new MALException());
+      this.value = "";
+    } else {
+      this.value = value;
     }
-    
-    this.value = value;
   }
 
   @Override
@@ -78,7 +80,6 @@ public class Identifier implements Attribute
 //  {
 //    this.value = value;
 //  }
-
   @Override
   public Long getShortForm()
   {
@@ -110,13 +111,13 @@ public class Identifier implements Attribute
   }
 
   @Override
- public void encode(final MALEncoder encoder) throws MALException
+  public void encode(final MALEncoder encoder) throws MALException
   {
     encoder.encodeIdentifier(this);
   }
 
   @Override
- public Element decode(final MALDecoder decoder) throws MALException
+  public Element decode(final MALDecoder decoder) throws MALException
   {
     return decoder.decodeIdentifier();
   }
@@ -124,16 +125,13 @@ public class Identifier implements Attribute
   @Override
   public boolean equals(final Object obj)
   {
-    if (null == obj)
-    {
+    if (null == obj) {
       return false;
     }
-    if (this == obj)
-    {
+    if (this == obj) {
       return true;
     }
-    if (!(obj instanceof Identifier))
-    {
+    if (!(obj instanceof Identifier)) {
       return false;
     }
     return this.value.equals(((Identifier) obj).value);

--- a/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/URI.java
+++ b/CCSDS_MAL_API/src/main/java/org/ccsds/moims/mo/mal/structures/URI.java
@@ -38,6 +38,7 @@ public class URI implements Attribute
    */
   public URI()
   {
+    this.value = "";
   }
 
   /**
@@ -52,9 +53,10 @@ public class URI implements Attribute
       Logger.getLogger(URI.class.getName()).log(Level.WARNING, 
           "The URI has been initialized with an invalid null value. Problems might occur while encoding the element.", 
           new MALException());
+      this.value = "";
+    } else {
+      this.value = value;
     }
-
-    this.value = value;
   }
 
   @Override


### PR DESCRIPTION
As a solution for [https://github.com/esa/CCSDS_MO_APIS/issues/17](https://github.com/esa/CCSDS_MO_APIS/issues/17) I suggest the following fixes. They just initialize the underlying values with empty strings to make the code more robust. Another possibility would be to forbid empty or null constructors.